### PR TITLE
Vc cc improvements

### DIFF
--- a/extern.h
+++ b/extern.h
@@ -186,7 +186,7 @@ char *cygdospath(char *src, int winpath);
 #endif
 
 #ifdef _WIN32
-#  define FileTimeTo_time_t(ft) ((time_t)((*((unsigned __int64 *)ft) - 116444736000000000ULL)/10000000ULL))
+#  define FileTimeTo_time_t(ft) ((time_t)((*((unsigned __int64 *)ft) - 116444736000000000)/10000000))
 #endif
 
 /* Get the working directory fall back code */

--- a/extern.h
+++ b/extern.h
@@ -43,6 +43,10 @@ sysintf.c(1132) : warning C4996: 'unlink' was declared deprecated
         Message: 'The POSIX name for this item is deprecated. Instead, use the I
 SO C++ conformant name: _unlink. See online help for details.' */
 #define _CRT_NONSTDC_NO_DEPRECATE
+/* get back some of the perf loss caused by >= VC 2005 dropping single threaded
+   static link CRT, this macro disables multithreading locks on some stdio
+   functions */
+#define _CRT_DISABLE_PERFCRIT_LOCKS
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif

--- a/extern.h
+++ b/extern.h
@@ -30,6 +30,19 @@
 /* For MSVC++ needs to include windows.h first to avoid problems with
  * type redefinitions. Include it also for MinGW for consistency. */
 #if defined(__MINGW32__) || defined(_MSC_VER)
+/* silence warnings about using null term strings in >= VC 2005
+sysintf.c(918) : warning C4996: 'strcat' was declared deprecated
+        Message: 'This function or variable may be unsafe. Consider using strcat
+_s instead. To disable deprecation, use _CRT_SECURE_NO_DEPRECATE. See online hel
+p for details.' */
+#define _CRT_SECURE_NO_DEPRECATE
+/* silence warnings about using POSIX name funcs in >= VC 2005
+sysintf.c(1132) : warning C4996: 'unlink' was declared deprecated
+        C:\Program Files\Microsoft Visual Studio 8\VC\INCLUDE\stdio.h(290) : see
+ declaration of 'unlink'
+        Message: 'The POSIX name for this item is deprecated. Instead, use the I
+SO C++ conformant name: _unlink. See online help for details.' */
+#define _CRT_NONSTDC_NO_DEPRECATE
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif

--- a/make.bat
+++ b/make.bat
@@ -41,10 +41,12 @@ echo    msc60        - Microsoft C 6.0 compile.
 echo    msc60swp     - Microsoft C 6.0, MASM 5.1 compile of swapping dmake.
 
 echo    win95-bcc50     - Borland C++ 5.0 32-bit compile of dmake.
-echo    win95-vpp40     - Microsoft VC++ 4.0 32-bit compile of dmake.
-echo    win95-vpp70     - MS VC++ ^>= 2003 optimized
-echo    win95-vpp70 rel - MS VC++ ^>= 2003 optimized
-echo    win95-vpp70 dbg - MS VC++ ^>= 2003 unoptimized for debugging
+echo    win95-vpp40     - Microsoft VC++ 4.0-6.0 optimized
+echo    win95-vpp40 rel - Microsoft VC++ 4.0-6.0 optimized
+echo    win95-vpp40 dbg - Microsoft VC++ 4.0-6.0 unoptimized for debugging
+echo    win95-vpp70     - MS VC++ ^>= 2003 32 or 64 bit optimized
+echo    win95-vpp70 rel - MS VC++ ^>= 2003 32 or 64 bit optimized
+echo    win95-vpp70 dbg - MS VC++ ^>= 2003 32 or 64 bit unoptimized 4 debugging
 goto end
 
 rem This is the script that makes dmake using Microsoft C 5.1

--- a/unix/dcache.c
+++ b/unix/dcache.c
@@ -35,11 +35,11 @@
 #undef __WIN32__
 #endif
 
+#include "extern.h"
 #ifdef __APPLE__
 #include <sys/types.h>
 #endif
 #include <dirent.h>
-#include "extern.h"
 #include <sysintf.h>
 
 

--- a/unix/runargv.c
+++ b/unix/runargv.c
@@ -106,8 +106,6 @@ _finished_child(pid, status) [unix/runargv] handles the finished child. If
   with runargv().
 */
 
-#include <signal.h>
-
 #include "extern.h"
 
 #ifdef HAVE_WAIT_H

--- a/win95/microsft/sysintf.h
+++ b/win95/microsft/sysintf.h
@@ -61,3 +61,7 @@ extern char * getcwd();
 #undef _POSIX_PATH_MAX
 #endif
 #define _POSIX_PATH_MAX _MAX_PATH
+
+#if _MSC_VER >= 1400
+#  define fputc(_c,_stream) _fputc_nolock(_c,_stream)
+#endif

--- a/win95/microsft/vpp40/mk.bat
+++ b/win95/microsft/vpp40/mk.bat
@@ -1,42 +1,60 @@
-if not "%1" == "" goto link 
+if not defined cc set "cc=cl"
+if not defined ld set "ld=link"
+
+if "%1" == "" goto optimized
+if "%1" == "rel" goto optimized
+
+set "c_opt=-Od -Gy -GF"
+set "ld_opt="
+goto build
+
+:optimized
+set "c_opt=-O2"
+set "ld_opt="
+
+:build
 if exist objects rd /S /Q objects
 if exist config.h del config.h
 if exist dmake.exe del dmake.exe
+if exist dmake.pdb del dmake.pdb
 md objects
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\infer.obj infer.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\make.obj make.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\stat.obj stat.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\expand.obj expand.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\dmstring.obj dmstring.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\hash.obj hash.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\dag.obj dag.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\dcache.obj unix\dcache.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\dmake.obj dmake.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\path.obj path.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\imacs.obj imacs.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\sysintf.obj sysintf.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\parse.obj parse.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\getinp.obj getinp.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\quit.obj quit.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\state.obj state.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\dmdump.obj dmdump.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\macparse.obj macparse.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\rulparse.obj rulparse.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\percent.obj percent.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\function.obj function.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\switchar.obj win95\switchar.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\dstrlwr.obj msdos\dstrlwr.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\arlib.obj msdos\arlib.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\dirbrk.obj msdos\dirbrk.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\infer.obj infer.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\make.obj make.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\stat.obj stat.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\expand.obj expand.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\dmstring.obj dmstring.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\hash.obj hash.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\dag.obj dag.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\dcache.obj unix\dcache.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\dmake.obj dmake.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\path.obj path.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\imacs.obj imacs.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\sysintf.obj sysintf.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\parse.obj parse.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\getinp.obj getinp.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\quit.obj quit.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\state.obj state.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\dmdump.obj dmdump.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\macparse.obj macparse.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\rulparse.obj rulparse.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\percent.obj percent.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\function.obj function.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\switchar.obj win95\switchar.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\dstrlwr.obj msdos\dstrlwr.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\arlib.obj msdos\arlib.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\dirbrk.obj msdos\dirbrk.c
 rem Not needed for MSVC 6 and up. Lesser versions not supported
-rem cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\tempnam.obj tempnam.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\ruletab.obj win95\microsft\ruletab.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\runargv.obj unix\runargv.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\rmprq.obj unix\rmprq.c
-cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo -Od -GF -Ge -Foobjects\allochnd.obj win95\microsft\allochnd.cpp
+rem %cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\tempnam.obj tempnam.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\ruletab.obj win95\microsft\ruletab.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\runargv.obj unix\runargv.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\rmprq.obj unix\rmprq.c
+%cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\allochnd.obj win95\microsft\allochnd.cpp
 
 :link
 rem link /nologo /out:dmake.exe @fix95nt\win95\microsft\vpp40\obj.rsp
-if "%c_flg%" == "" link /out:dmake.exe @.\win95\microsft\vpp40\obj.rsp
-if not "%c_flg%" == "" link /DEBUG:notmapped,full /DEBUGTYPE:cv /PDB:NONE /out:dmake.exe @.\win95\microsft\vpp40\obj.rsp
+%ld% /out:dmake.exe -debug -opt:icf,ref %ld_opt% @.\win95\microsft\vpp40\obj.rsp
 copy win95\microsft\vpp40\template.mk startup\config.mk
+
+rem clean up our env vars so they dont leak to cmd shell
+set "c_opt="
+set "ld_opt="

--- a/win95/microsft/vpp40/mk70.bat
+++ b/win95/microsft/vpp40/mk70.bat
@@ -16,6 +16,7 @@ set "ld_opt=-ltcg"
 if exist objects rd /S /Q objects
 if exist config.h del config.h
 if exist dmake.exe del dmake.exe
+if exist dmake.pdb del dmake.pdb
 md objects
 %cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\infer.obj infer.c
 %cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\make.obj make.c
@@ -43,7 +44,7 @@ md objects
 %cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\arlib.obj msdos\arlib.c
 %cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\dirbrk.obj msdos\dirbrk.c
 rem Not needed for MSVC 6 and up. Lesser versions not supported
-rem cl -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\tempnam.obj tempnam.c
+rem %cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\tempnam.obj tempnam.c
 %cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\ruletab.obj win95\microsft\ruletab.c
 %cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\runargv.obj unix\runargv.c
 %cc% -c %c_flg% -I. -Iwin95 -Iwin95\microsft -Iwin95\microsft\vpp40 /nologo %c_opt% -Zi -Foobjects\rmprq.obj unix\rmprq.c

--- a/win95/switchar.c
+++ b/win95/switchar.c
@@ -23,9 +23,7 @@
 --      Use cvs log to obtain detailed change logs.
 */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include "stdmacs.h"
+#include "extern.h"
 
 getswitchar()/*
 ===============

--- a/winnt/microsft/sysintf.h
+++ b/winnt/microsft/sysintf.h
@@ -47,3 +47,7 @@ extern char * getcwd();
 #undef _POSIX_PATH_MAX
 #endif
 #define _POSIX_PATH_MAX _MAX_PATH
+
+#if _MSC_VER >= 1400
+#  define fputc(_c,_stream) _fputc_nolock(_c,_stream)
+#endif

--- a/winnt/mingw/sysintf.h
+++ b/winnt/mingw/sysintf.h
@@ -52,3 +52,5 @@ extern char * getcwd();
 #undef _POSIX_PATH_MAX
 #endif
 #define _POSIX_PATH_MAX _MAX_PATH
+
+#define fputc(_c,_stream) _fputc_nolock(_c,_stream)

--- a/winnt/msvc6/sysintf.h
+++ b/winnt/msvc6/sysintf.h
@@ -52,3 +52,7 @@ extern char * getcwd();
 #undef _POSIX_PATH_MAX
 #endif
 #define _POSIX_PATH_MAX _MAX_PATH
+
+#if _MSC_VER >= 1400
+#  define fputc(_c,_stream) _fputc_nolock(_c,_stream)
+#endif


### PR DESCRIPTION
fix a syntax error with VC 6, make a "release" optimized VC 6 option, VC 2005 and newer warnings fixes, a slight perf improvement on VC 2005 and newer as compared to the previous situation, but VC 2003 and earlier builds will always be faster than a VC 2005 or newer build of dmake. The vast majority of stdio is not available in _nolock versions thanks to MS so only fputc got optimized to a nolock version, its still something.